### PR TITLE
Potential fix for duplicate PDF pages across prints

### DIFF
--- a/Logic/PdfToBitmapListConverter.cs
+++ b/Logic/PdfToBitmapListConverter.cs
@@ -23,14 +23,15 @@ namespace Jds2
             EnsureGsDllExists();
 
             var outputList = new List<Bitmap>();
-                
-            var outputTempFile = Path.GetTempFileName().Replace(".tmp", ".png");
+            var outputTempFile = Path.Join(Path.GetTempPath(), $"{Guid.NewGuid()}.png");
 
             _ = Pdf2Image.Convert(pdfFileToWork, outputTempFile);
 
             var pagePaths = GetAllMatchingPagePngs(Path.GetFileNameWithoutExtension(outputTempFile));
-     
             ConvertFilePathList(pagePaths, outputList);
+            
+            foreach (var path in pagePaths)
+                File.Delete(path);
             
             return outputList;
         }
@@ -79,8 +80,7 @@ namespace Jds2
         {
             var ghostScriptMutex = new Mutex(false, ResourceStrings.GhostScriptMutexString);
 
-            var outputTempFile = Path.GetTempFileName().Replace(".tmp", ".png");
-                
+            var outputTempFile = Path.Join(Path.GetTempPath(), $"{Guid.NewGuid()}.png");
             var pagePaths = GetAllMatchingPagePngs(Path.GetFileNameWithoutExtension(outputTempFile));  
                 
             try
@@ -88,9 +88,7 @@ namespace Jds2
                 ghostScriptMutex.WaitOne(10000);
                 
                 _ = Pdf2Image.Convert(pdfFileToWork, outputTempFile);
-
-            }
-            finally
+            } finally
             {
                 ghostScriptMutex.ReleaseMutex();
             }


### PR DESCRIPTION
Happy Tuesday,

First off, I'd like to say thanks for working on this.  It served helpful with a finicky printer which didn't like printing raw PDFs.

While `Path.GetTempFileName()` returns unique names, replacing the ".tmp" file extension with ".png" negates that guarantee.  I've seen general advice to avoid `Path.GetTempFileName()`.

These changes address an issue where temporary filenames collide, and we saw vast duplication of print data.  Our client's printers spat out hundreds of extra pages from "old" documents whose pages had the same name as pages from new PDFs.

The temporary PNG files are named with a GUID to mitigate the name collisions.

Have a good week,
\---
Zach Goethel